### PR TITLE
EVE-13: Updated cache action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache .NET dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.nuget/packages


### PR DESCRIPTION
## Changes

- Updated cache action to v4

Closes: #13 
